### PR TITLE
Dependency fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,9 +247,9 @@
 			<version>3.3</version>
 		</dependency>
 		<dependency>
-			<groupId>org.ostermiller</groupId>
-			<artifactId>utils</artifactId>
-			<version>1.07.00</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-csv</artifactId>
+			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -194,9 +194,9 @@
 			<version>1.2.0</version>
 		</dependency>
 		<dependency>
-			<groupId>com.seventytwomiles</groupId>
+			<groupId>org.architecturerules</groupId>
 			<artifactId>architecture-rules</artifactId>
-			<version>2.1.1</version>
+			<version>3.0.0-rc1</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -256,15 +256,9 @@
 
 	<repositories>
 		<repository>
-			<id>architecture-rules-repo</id>
-			<name>architecture-rules repository hosted by code.google.com</name>
-			<url>http://architecturerules.googlecode.com/svn/maven2/</url>
-			<releases>
-				<checksumPolicy>ignore</checksumPolicy>
-			</releases>
-			<snapshots>
-				<checksumPolicy>ignore</checksumPolicy>
-			</snapshots>
+			<id>smartics</id>
+			<name>smartics</name>
+			<url>https://www.smartics.eu/nexus/content/groups/public-group/</url>
 		</repository>
 	</repositories>
 

--- a/src/test/java/com/joptimizer/ArchitectureRulesUnitTest.java
+++ b/src/test/java/com/joptimizer/ArchitectureRulesUnitTest.java
@@ -18,7 +18,7 @@ package com.joptimizer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import com.seventytwomiles.architecturerules.AbstractArchitectureRulesConfigurationTest;
+import org.architecturerules.AbstractArchitectureRulesConfigurationTest;
 
 public class ArchitectureRulesUnitTest extends AbstractArchitectureRulesConfigurationTest {
 

--- a/src/test/java/com/joptimizer/util/TestUtils.java
+++ b/src/test/java/com/joptimizer/util/TestUtils.java
@@ -2,19 +2,26 @@ package com.joptimizer.util;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.List;
+import java.util.Locale;
 
-import com.Ostermiller.util.CSVParser;
-import com.Ostermiller.util.CSVPrinter;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
 
 public final class TestUtils {
 
 	
 	public static final void writeDoubleArrayToFile(double[] v, String fileName) throws Exception {
-		CSVPrinter csvPrinter = new CSVPrinter(new FileOutputStream(new File(fileName)));
-		DecimalFormat df = new DecimalFormat("#");
-        df.setMaximumFractionDigits(16);
+		DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(Locale.US);
+		df.applyPattern("#");
+		df.setMaximumFractionDigits(16);
 		String[][] ret = new String[v.length][1];
 		for(int j=0; j<v.length; j++){
 			if(Double.isNaN(v[j])){
@@ -24,14 +31,18 @@ public final class TestUtils {
 				//ret[j][0] = String.valueOf(v[j]);
 			}
 		}
-		csvPrinter.println(ret);
+		CSVPrinter csvPrinter = new CSVPrinter(new FileWriter(fileName), CSVFormat.DEFAULT.withDelimiter(','));
+		try{
+			csvPrinter.printRecords(ret);
+		}finally{
+			csvPrinter.close();
+		}
 	}
 	
 	public static final void writeDoubleMatrixToFile(double[][] m, String fileName) throws Exception {
-		CSVPrinter csvPrinter = new CSVPrinter(new FileOutputStream(new File(fileName)));
-		DecimalFormat df = new DecimalFormat("#");
-        df.setMaximumFractionDigits(16);
-		csvPrinter.changeDelimiter(" ".charAt(0));
+		DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(Locale.US);
+		df.applyPattern("#");
+		df.setMaximumFractionDigits(16);
 		String[][] ret = new String[m.length][];
 		for(int i=0; i<m.length; i++){
 			double[] MI = m[i];
@@ -46,31 +57,34 @@ public final class TestUtils {
 			}
 			ret[i] = retI;
 		}
-		csvPrinter.println(ret);
+		CSVPrinter csvPrinter = new CSVPrinter(new FileWriter(fileName), CSVFormat.DEFAULT.withDelimiter(' '));
+		try{
+			csvPrinter.printRecords(ret);
+		}finally{
+			csvPrinter.close();
+		}
 	}
 	
 	public static final double[] loadDoubleArrayFromFile(String classpathFileName) throws Exception {
 		//FileReader fr = new FileReader(classpathFileName);
 		InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(classpathFileName);
-		CSVParser parser = new CSVParser(is, ',');
-		parser.setCommentStart("#");
-		String[][] mapMatrix = parser.getAllValues();
-		double[] v = new double[mapMatrix.length];
-		for(int i=0; i<mapMatrix.length; i++){
-			v[i] = Double.parseDouble(mapMatrix[i][0]);
+		CSVParser parser = new CSVParser(new InputStreamReader(is), CSVFormat.DEFAULT.withDelimiter(',').withCommentMarker('#'));
+		List<CSVRecord> records = parser.getRecords();
+		double[] v = new double[records.size()];
+		for(int i=0; i<records.size(); i++){
+			v[i] = Double.parseDouble(records.get(i).get(0));
 		}
 		return v;
 	}
 	
 	public static final double[][] loadDoubleMatrixFromFile(String classpathFileName, char fieldSeparator) throws Exception {
 		InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(classpathFileName);
-		CSVParser parser = new CSVParser(is, fieldSeparator);
-		parser.setCommentStart("#");
-		String[][] mapMatrix = parser.getAllValues();
-		double[][] m = new double[mapMatrix.length][mapMatrix[0].length];
-		for(int i=0; i<mapMatrix.length; i++){
-			for(int j=0; j<mapMatrix[0].length; j++){
-				m[i][j] = Double.parseDouble(mapMatrix[i][j]);
+		CSVParser parser = new CSVParser(new InputStreamReader(is), CSVFormat.DEFAULT.withDelimiter(fieldSeparator).withCommentMarker('#'));
+		List<CSVRecord> records = parser.getRecords();
+		double[][] m = new double[records.size()][records.get(0).size()];
+		for(int i=0; i<records.size(); i++){
+			for(int j=0; j<records.get(0).size(); j++){
+				m[i][j] = Double.parseDouble(records.get(i).get(j));
 			}
 		}
 		return m;


### PR DESCRIPTION
A few years ago I noticed that JOptimizer 3.4.0 has a GPL library among its (test-time) dependencies, which is incompatible with the project's Apache license. I sent a fix to the developers, and they accepted my patch, but sadly they decided to release the next version (3.5.0) under the Creative Commons BY-ND license, which was in conflict with the license of the project I intended to use JOptimizer in. I ended up keeping a local fork of JOptimizer 3.4.0 with my patch applied.

The last official release of JOptimizer was in 2018, and its homepage disappeared around 2019. It would be sad to see such a useful tool disappear from the face of the world, so I am resubmitting the aforementioned patch (+ a build fix) to you. It would be awesome if you could take these patches and deploy a new release to the Central Repository, so that everyone could benefit from the "reduction in legal ambiguity" - and I could finally drop my local copy of the code.